### PR TITLE
Avionics / Heat Shield attachment fix via NodeResizer plugin

### DIFF
--- a/GameData/SDHI/Service Module System/Parts/MM_configs/SDHI_SMS_MMPatch_NodeResizer.cfg
+++ b/GameData/SDHI/Service Module System/Parts/MM_configs/SDHI_SMS_MMPatch_NodeResizer.cfg
@@ -1,0 +1,40 @@
+@PART[SDHI_2.5_Heatshield]:NEEDS[NodeResizer]
+{
+	@node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.1, 0.0, 0.0, 1.0, 0.0, 0
+
+	MODULE
+	{
+		name = ModuleNodeResizer
+		AttachNode
+		{
+			name = top
+			newsize = 2
+		}
+		AttachNode
+		{
+			name = bottom
+			newsize = 2
+		}		
+	}
+}
+@PART[SDHI_2.5_AvionicsRing]:NEEDS[NodeResizer]
+{
+	@node_stack_top = 0.0, 0.08625, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+
+	MODULE
+	{
+		name = ModuleNodeResizer
+		AttachNode
+		{
+			name = top
+			newsize = 2
+		}
+		AttachNode
+		{
+			name = bottom
+			newsize = 2
+		}		
+	}
+}


### PR DESCRIPTION
MM Config to:
- Change starting top/bottom stack nodes to 0 (smallest possible. Hope it's enough for players...)
- Add ModuleNodeResizer to Avionics Ring & Heat Shield to resize stack nodes back up to 2 once vehicle is in the world.
