### PR TITLE
Add an adapter for use without engine

### DIFF
--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleAdapterNoEngine/part.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleAdapterNoEngine/part.cfg
@@ -1,0 +1,45 @@
+PART
+{
+	name = SDHI_2.5_ServiceModuleAdapter
+	module = Part
+	author = sumghai / alcaeus
+
+	MODEL {
+		model = SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleAdapter/model
+	}
+
+	scale = 1
+	rescaleFactor = 1.25
+
+	node_stack_top = 0.0, 0.744749, 0.0, 0.0, 1.0, 0.0
+	node_stack_bottom = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
+	node_stack_connect1 = 1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_connect2 = -1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
+
+	TechRequired = supersonicFlight
+	entryCost = 2200
+	cost = 1100
+	category = Aero
+	subcategory = 0
+	title = SDHI 2.5m Service Module Adapter (engineless)
+	manufacturer = Sum Dum Heavy Industries Co., Ltd
+	description = A stack decoupler designed for mating the SDHI Service Module system with any 2.5m lifter/upper stage fuselage when using it with a different propulsion stage. Fairings sold separately.
+
+	attachRules = 1,0,1,1,1
+	stackSymmetry = 1
+
+	mass = 1
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 9
+	maxTemp = 3400
+	fuelCrossFeed = True
+
+	breakingForce = 2000
+	breakingTorque = 2000
+
+	stageOffset = 1
+	childStageOffset = 1
+}


### PR DESCRIPTION
When designing spaceships with the SDHI service module I've often come across limitations due to the small engine and fuel size. I was looking for something to allow for propulsion stages as shown in some renders for the new ATV based Service Module: https://commons.wikimedia.org/wiki/File:Orion_Service_Module.jpg

This PR is a starting point - nothing more. It takes the default adapter and changes the following:
- Change top stack attachment points to the bottom of the SM
- Enable fuel crossfeed
- Disable decoupler functionality

That is as far as I can go, I don't have any skill making 3d models or textures. The adapter looks ok, but looking at the spaceship from the bottom there's still the black hole where the engine usually sits.

@sumghai is this something you'd like to add to the pack?

NB: I've tested the part, it works as intended so far. I've only now removed the decoupling functionality, still needs testing as this is the first time I've touched KSP config files.