### PR TITLE
Updated costs and masses to be in line with stock parts.

### DIFF
--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
@@ -35,9 +35,9 @@ PART
 	
 	attachRules = 1,0,1,1,1
 
-	CoMOffset = 0, -1, 0
+	CoMOffset = 0, 0.2, 0
 	
-	mass = .48
+	mass = 0.48
 	dragModelType = default
 	maximum_drag = 0.3
 	minimum_drag = 0.3

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
@@ -25,8 +25,8 @@ PART
 	node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	
 	TechRequired = specializedControl
-	entryCost = 1200
-	cost = 600
+	entryCost = 4660
+	cost = 2330
 	category = Structural
 	subcategory = 0
 	title = SDHI 2.5m Avionics Ring
@@ -37,7 +37,7 @@ PART
 
 	CoMOffset = 0, -1, 0
 	
-	mass = 2.2
+	mass = .48
 	dragModelType = default
 	maximum_drag = 0.3
 	minimum_drag = 0.3

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/AvionicsRing.cfg
@@ -25,8 +25,8 @@ PART
 	node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	
 	TechRequired = specializedControl
-	entryCost = 4660
-	cost = 2330
+	entryCost = 4600
+	cost = 2300
 	category = Structural
 	subcategory = 0
 	title = SDHI 2.5m Avionics Ring

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -25,8 +25,8 @@ PART
 	node_stack_bottom = 0.0, -0.84375, 0.0, 0.0, -1.0, 0.0, 2
 	
 	TechRequired = heavierRocketry
-	entryCost = 7500
-	cost = 2500
+	entryCost = 16750
+	cost = 3350
 	category = Propulsion
 	subcategory = 0
 	title = SDHI 2.5m Service Module
@@ -37,7 +37,7 @@ PART
 
 	CoMOffset = 0, -1, 0
 	
-	mass = 2.2
+	mass = 1.1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -35,7 +35,7 @@ PART
 	
 	attachRules = 1,0,1,1,1
 
-	CoMOffset = 0, -1, 0
+	CoMOffset = 0, -0.2, 0
 	
 	mass = 1.1
 	dragModelType = default
@@ -46,7 +46,7 @@ PART
 	breakingForce = 280
 	breakingTorque = 280
 	maxTemp = 2000
-	bulkheadProfiles = size2, srf
+	bulkheadProfiles = size2
 	
 	fuelCrossFeed = true
 	

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -25,7 +25,7 @@ PART
 	node_stack_bottom = 0.0, -0.84375, 0.0, 0.0, -1.0, 0.0, 2
 	
 	TechRequired = heavierRocketry
-	entryCost = 16750
+	entryCost = 10050
 	cost = 3350
 	category = Propulsion
 	subcategory = 0

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -17,7 +17,7 @@ PART
 		position = 0.0, 0.5625, -1.206125
 	}
 
-	rescaleFactor = 1.0
+	rescaleFactor = 1.1
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z, Node Size

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -37,7 +37,7 @@ PART
 
 	CoMOffset = 0, -1, 0
 	
-	mass = 1.1
+	mass = 1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/ServiceModule.cfg
@@ -17,7 +17,7 @@ PART
 		position = 0.0, 0.5625, -1.206125
 	}
 
-	rescaleFactor = 1.1
+	rescaleFactor = 1.0
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z, Node Size
@@ -37,7 +37,7 @@ PART
 
 	CoMOffset = 0, -1, 0
 	
-	mass = 1
+	mass = 1.1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3

--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleAdapter/part.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleAdapter/part.cfg
@@ -16,8 +16,8 @@ PART
 	node_stack_connect2 = -1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
 	
 	TechRequired = supersonicFlight
-	entryCost = 2200
-	cost = 1100
+	entryCost = 1800
+	cost = 900
 	category = Aero
 	subcategory = 0
 	title = SDHI 2.5m Service Module Adapter
@@ -27,7 +27,7 @@ PART
 	attachRules = 1,0,1,1,1
 	stackSymmetry = 1
 	
-	mass = 1
+	mass = 0.2
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -36,8 +36,8 @@ PART
 	maxTemp = 2400
 	fuelCrossFeed = False
 
-	breakingForce = 2000
-	breakingTorque = 2000
+	breakingForce = 200
+	breakingTorque = 200
 
 	stageOffset = 1
 	childStageOffset = 1


### PR DESCRIPTION
Looking at the prices (mass and funds) of stock or stockalike parts that provide equivalent benefits to your service module parts (2x Z-100, fuel cell, MRS decoupler, FL-T800 or X200-8 tank, small inline reaction wheels, and QBE), there's been some divergence.  I can provide the gory details if you like, but the short version is that the avionics ring needs to weigh less and cost more, and the additional cost and mass of the service module beyond the avionics ring now includes the tank dry masses and costs.

(The research costs could probably also stand to increase, since stock parts have them 5-10x the purchase price instead of 2-3x as you have them, but I haven't played any hard-mode saves with development costs, so I've left them as is.)