### PR TITLE
Update part.cfg

### DIFF
--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleFairing/part.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_ServiceModuleFairing/part.cfg
@@ -45,7 +45,7 @@ PART
 
 	MODULE
 	{
-		name = ModuleAnimatedAnchoredDecoupler
+		name = ModuleAnimatedDecoupler
 		anchorName = anchor
 		ejectionForce = 100
 		explosiveNodeID = bottom


### PR DESCRIPTION
Change ModuleAnimatedAnchoredDecoupler to ModuleAnimatedDecoupler. The former is lacking recent changes to the latter, and the fairings aren't really 'anchored' decouplers anyway. Anchored decouplers are the ones that split and leave a portion of the model on each part that is being decoupled.

(this should help alleviate the issue where parts remain occluded by the fairing)