### PR TITLE
Change module order in AeroShround

### DIFF
--- a/GameData/SDHI/Service Module System/Parts/SDHI_2.5_Mk1-2AeroShroud/part.cfg
+++ b/GameData/SDHI/Service Module System/Parts/SDHI_2.5_Mk1-2AeroShroud/part.cfg
@@ -103,12 +103,6 @@ PART
 		}
 	}
 	
-	MODULE
-	{
-	    name = ModuleAnimatedDecoupler
-	    ejectionForce = 0 //200
-	    explosiveNodeID = bottom
-	}
 
 	MODULE
     {
@@ -138,6 +132,12 @@ PART
      	}
     	
     }
+
+	MODULE {
+	    name = ModuleAnimatedDecoupler
+	    ejectionForce = 0 //200
+	    explosiveNodeID = bottom
+	}
     
     RESOURCE
     {


### PR DESCRIPTION
Change module order in AeroShround to allow to activate using action groups. 
In the old order, not activate the solid engine, only decouple.